### PR TITLE
Add feature to publish episodes

### DIFF
--- a/src/app/account/show/detail/episodes/show-episodes.component.html
+++ b/src/app/account/show/detail/episodes/show-episodes.component.html
@@ -57,7 +57,7 @@
                 <mat-icon>more_vert</mat-icon>
               </button>
               <mat-menu #menu="matMenu">
-                <button mat-menu-item *ngIf="element.status === 'drafted'">
+                <button mat-menu-item *ngIf="element.status === 'drafted'" (click)="handlePublishEpisode(element.id)">
                   <mat-icon [svgIcon]="'heroicons_outline:rss'"></mat-icon>
                   <span>Publish</span>
                 </button>

--- a/src/app/account/show/detail/episodes/show-episodes.component.ts
+++ b/src/app/account/show/detail/episodes/show-episodes.component.ts
@@ -1,6 +1,7 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {PageEvent} from '@angular/material/paginator';
 import {Router} from '@angular/router';
+import {AlertService} from '../../../../shared/services/alert.service';
 import {EpisodesService} from '../../../../shared/services/episodes.service';
 
 @Component({
@@ -18,7 +19,8 @@ export class ShowEpisodesComponent implements OnInit {
 
   constructor(
     private router: Router,
-    private episodesService: EpisodesService
+    private episodesService: EpisodesService,
+    private alertService: AlertService
   ) {
   }
 
@@ -63,5 +65,15 @@ export class ShowEpisodesComponent implements OnInit {
       default:
         return 'DRAFT';
     }
+  }
+
+  handlePublishEpisode(id: string): void {
+    const data: any = {status: 'enabled'};
+    this.episodesService.updateEpisodeStatus(data, id).subscribe(response => {
+      this.episodesService.showEpisodesList(this.show.id, this.page).subscribe(response => {
+        this.episodes = response.result;
+      });
+      this.alertService.success('Episode published successfully!');
+    });
   }
 }

--- a/src/app/shared/services/episodes.service.ts
+++ b/src/app/shared/services/episodes.service.ts
@@ -1,6 +1,7 @@
 import {ApiService} from './api.service';
 import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
+import {data} from 'autoprefixer';
 
 @Injectable({
   providedIn: 'root'
@@ -12,6 +13,10 @@ export class EpisodesService extends ApiService {
 
   updateEpisode(formData: any, id: any): Observable<any> {
     return this.patch('v1/episodes/' + id, formData);
+  }
+
+  updateEpisodeStatus(data: any, id: any): Observable<any> {
+    return this.patch('v1/episodes/status/' + id, data);
   }
 
   showEpisodesList(showId: any, page: number): Observable<any> {


### PR DESCRIPTION
Imported AlertService in show-episodes component as part of this revision. Also, a new function handlePublishEpisode has been introduced to manage the process of publishing episodes. This function, which is now linked to the "Publish" button in the front-end, uses the updateEpisodeStatus method in the episodes service to switch the status of an episode to 'enabled'. The alertService provides a success message upon successful completion.